### PR TITLE
Bugfix: fixed uninitialized pointer in TraversabilityGrid

### DIFF
--- a/src/maps/TraversabilityGrid.cpp
+++ b/src/maps/TraversabilityGrid.cpp
@@ -213,6 +213,7 @@ void TraversabilityGrid::setTraversabilityArray()
     if(!traversabilityArray)
     {
         traversabilityArray = &(getData<ArrayType>(TRAVERSABILITY));
+		traversabilityArray->resize(boost::extents[getCellSizeY()][getCellSizeX()]);
     }
 }
 

--- a/src/maps/TraversabilityGrid.hpp
+++ b/src/maps/TraversabilityGrid.hpp
@@ -141,14 +141,15 @@ private:
     void setProbabilityArray();
     void setTraversabilityArray();
 public:
-    TraversabilityGrid() : Grid<uint8_t>(), probabilityArray(NULL) 
+    TraversabilityGrid() : Grid<uint8_t>(), probabilityArray(NULL), traversabilityArray(NULL)
     {
         traversabilityClasses.resize(std::numeric_limits<uint8_t>::max());
     };
     TraversabilityGrid(size_t cellSizeX, size_t cellSizeY, 
                         double scalex, double scaley, 
                         double offsetx = 0.0, double offsety = 0.0,
-                        std::string const& id = Environment::ITEM_NOT_ATTACHED):Grid<uint8_t>::Grid(cellSizeX,cellSizeY,scalex,scaley,offsetx, offsety, id), probabilityArray(NULL)
+                        std::string const& id = Environment::ITEM_NOT_ATTACHED):Grid<uint8_t>::Grid(cellSizeX,cellSizeY,scalex,scaley,offsetx, offsety, id), 
+                        probabilityArray(NULL), traversabilityArray(NULL)
     {
         traversabilityClasses.resize(std::numeric_limits<uint8_t>::max());
     };


### PR DESCRIPTION
Due to uninitialized pointer, the traversability grid can cause a segmentation fault when using it "raw" as TraversabilityGrid* t = new TraversabilityGrid()