### PR TITLE
use std::regex instead of boost::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
+rock_activate_cxx11()
+
 option( USE_CGAL "Switch on CGAL related functionality" OFF )
 include(${PROJECT_SOURCE_DIR}/cmake/UseCGAL.cmake)
 if (USE_CGAL)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -59,7 +59,7 @@ rock_executable(env_mls_slopes env_mls_slopes.cpp
 
 rock_executable(env_slam6d env_slam6d.cpp
     DEPS envire
-    DEPS_PLAIN Boost_FILESYSTEM Boost_SYSTEM Boost_REGEX
+    DEPS_PLAIN Boost_FILESYSTEM Boost_SYSTEM
     )
 
 rock_executable(asc2ply asc2ply.cpp

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -57,10 +57,19 @@ rock_executable(env_traversability env_traversability.cpp
 rock_executable(env_mls_slopes env_mls_slopes.cpp
     DEPS envire)
 
-rock_executable(env_slam6d env_slam6d.cpp
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+    add_definitions(-DHAVE_STD_REGEX)
+    rock_executable(env_slam6d env_slam6d.cpp
     DEPS envire
     DEPS_PLAIN Boost_FILESYSTEM Boost_SYSTEM
     )
+else()
+    rock_executable(env_slam6d env_slam6d.cpp
+    DEPS envire
+    DEPS_PLAIN Boost_FILESYSTEM Boost_SYSTEM Boost_REGEX
+    )
+endif()
+
 
 rock_executable(asc2ply asc2ply.cpp
     DEPS envire

--- a/tools/env_slam6d.cpp
+++ b/tools/env_slam6d.cpp
@@ -4,7 +4,7 @@
 #include "boost/scoped_ptr.hpp"
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 
@@ -18,9 +18,9 @@ using namespace std;
 using namespace boost::filesystem;
 using boost::format;
 using boost::str;
-using boost::regex;
-using boost::regex_match;
-using boost::smatch;
+//using boost::regex;
+//using boost::regex_match;
+//using boost::smatch;
 using boost::lexical_cast;
      
 void usage()
@@ -123,8 +123,8 @@ int main( int argc, char* argv[] )
 	boost::scoped_ptr<Environment> env( Environment::unserialize( env_dat ) );
 
 	path slam6d_dir = slam6d_dat;
-	regex rx("scan(\\d{3})\\.frames");
-	smatch r;
+	std::regex rx("scan(\\d{3})\\.frames");
+	std::smatch r;
 	for( directory_iterator it( slam6d_dir ); it != directory_iterator(); it++ )
 	{
 	    string file_name = it->path().string();

--- a/tools/env_slam6d.cpp
+++ b/tools/env_slam6d.cpp
@@ -4,7 +4,17 @@
 #include "boost/scoped_ptr.hpp"
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <regex>
+
+#ifdef HAVE_STD_REGEX
+    #include <regex>
+    using std::regex;
+    using std::smatch;
+#else
+    #include <boost/regex.hpp>
+    using boost::regex;
+    using boost::smatch;
+#endif
+
 #include <boost/lexical_cast.hpp>
 #include <boost/version.hpp>
 
@@ -18,9 +28,6 @@ using namespace std;
 using namespace boost::filesystem;
 using boost::format;
 using boost::str;
-//using boost::regex;
-//using boost::regex_match;
-//using boost::smatch;
 using boost::lexical_cast;
      
 void usage()
@@ -123,8 +130,8 @@ int main( int argc, char* argv[] )
 	boost::scoped_ptr<Environment> env( Environment::unserialize( env_dat ) );
 
 	path slam6d_dir = slam6d_dat;
-	std::regex rx("scan(\\d{3})\\.frames");
-	std::smatch r;
+	regex rx("scan(\\d{3})\\.frames");
+	smatch r;
 	for( directory_iterator it( slam6d_dir ); it != directory_iterator(); it++ )
 	{
 	    string file_name = it->path().string();


### PR DESCRIPTION
Using boost::regex with gcc5 on ubuntu 16.10 results in linker errors, but slam-envire has to be build with gcc5 as libply does not compile using gcc6 and boost 1.61 on ubuntu 16.10.

This way, slam-envire compiles fine
