### PR TITLE
fix bind from complaining about  unresolved overloaded function type

### DIFF
--- a/viz/EnvireVisualization.cpp
+++ b/viz/EnvireVisualization.cpp
@@ -28,8 +28,9 @@ EnvireVisualization::EnvireVisualization()
     // setup eventlistener
     eventListener = boost::shared_ptr<EnvireEventListener>(
 	    new EnvireEventListener( 
-		boost::bind( &osg::Group::addChild<osg::Node>, ownNode->asGroup(), _1 ),
-		boost::bind( &osg::Group::removeChild<osg::Node>, ownNode->asGroup(), _1 ) ) );
+            [this](osg::Node* n) { ownNode->asGroup()->addChild(n);},
+            [this](osg::Node* n) { ownNode->asGroup()->removeChild(n);}
+         ) );
 
     // create and register visualizers
     // NOTE: the visualizers at the back have higher priority 

--- a/viz/EnvireVisualization.cpp
+++ b/viz/EnvireVisualization.cpp
@@ -28,8 +28,8 @@ EnvireVisualization::EnvireVisualization()
     // setup eventlistener
     eventListener = boost::shared_ptr<EnvireEventListener>(
 	    new EnvireEventListener( 
-		boost::bind( &osg::Group::addChild, ownNode->asGroup(), _1 ),
-		boost::bind( &osg::Group::removeChild, ownNode->asGroup(), _1 ) ) );
+		boost::bind( &osg::Group::addChild<osg::Node>, ownNode->asGroup(), _1 ),
+		boost::bind( &osg::Group::removeChild<osg::Node>, ownNode->asGroup(), _1 ) ) );
 
     // create and register visualizers
     // NOTE: the visualizers at the back have higher priority 


### PR DESCRIPTION
I could not test if visualization still works, test cases are crashing :-(

error message on ubuntu18.04 with osg 3.4 was:

```
slam/envire/viz/EnvireVisualization.cpp:31:62: error: no matching function for call to ‘bind(<unresolved overloaded function type>, osg::Group*, const boost::arg<1>&)’
   boost::bind( &osg::Group::addChild, ownNode->asGroup(), _1 ),
                                                              ^
In file included from /usr/include/boost/bind.hpp:22:0,
                 from /home/dfki.uni-bremen.de/planthaber/dfki/rock/transfit/slam/envire/viz/EnvireVisualization.cpp:2:
/usr/include/boost/bind/bind.hpp:1875:5: note: candidate: template<class R, class F> boost::_bi::bind_t<R, F, boost::_bi::list0> boost::bind(F)
     BOOST_BIND(F f)
     ^
```