### PR TITLE
Build with C++14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
-rock_activate_cxx11()
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option( USE_CGAL "Switch on CGAL related functionality" OFF )
 include(${PROJECT_SOURCE_DIR}/cmake/UseCGAL.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 option( USE_CGAL "Switch on CGAL related functionality" OFF )
 include(${PROJECT_SOURCE_DIR}/cmake/UseCGAL.cmake)
 if (USE_CGAL)


### PR DESCRIPTION
CGAL 5 in Ubuntu 20.04 requires C++14 to compile