### PR TITLE
Build with C++14 support explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option( USE_CGAL "Switch on CGAL related functionality" OFF )
 include(${PROJECT_SOURCE_DIR}/cmake/UseCGAL.cmake)
 if (USE_CGAL)


### PR DESCRIPTION
Recreation of https://github.com/rock-slam/slam-envire/pull/14 because of https://github.com/rock-slam/slam-envire/pull/15. Needed for build on Ubuntu 20.04. Request for C++14 is now explicit to make sure lower defaults are overwritten.