### PR TITLE
add "set(CMAKE_CXX_EXTENSIONS OFF)" to the params

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_op
 include_directories(${Boost_INCLUDE_DIRS})
 
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option( USE_CGAL "Switch on CGAL related functionality" OFF )


### PR DESCRIPTION
Apparently needed to compile under all circumstances in ubuntu18.04 and to be compatible wich rock_activate_cxx11()
