### PR TITLE
Make CMAKE_CXX_STANDARD overridable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,15 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
-option(CMAKE_CXX_STANDARD "CXX standard" 14)
-set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+# on ubutnu 16.04 using c++14 runs into this cashxml error:
+# https://github.com/CastXML/CastXML/issues/76
+# option can be removed once it is resolved in the deb package
+option(USE_CXX_11 "USE c++11 instead of c++14" OFF)
+if (USE_CXX_11)
+    set(CMAKE_CXX_STANDARD 11)
+else()
+    set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
-set(CMAKE_CXX_STANDARD 14)
+option(CMAKE_CXX_STANDARD "CXX standard" 14)
+set(CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,9 @@ rock_find_pkgconfig(EIGEN3 eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread system regex program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
-# on ubutnu 16.04 using c++14 runs into this cashxml error:
-# https://github.com/CastXML/CastXML/issues/76
-# option can be removed once it is resolved in the deb package
-option(USE_CXX_11 "USE c++11 instead of c++14" OFF)
-if (USE_CXX_11)
-    set(CMAKE_CXX_STANDARD 11)
-else()
-    set(CMAKE_CXX_STANDARD 14)
+# make cxx standard selectable
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
builds on ubuntu 16.04 are failing with cxx14 due to 
https://github.com/CastXML/CastXML/issues/76