### PR TITLE
Feature/qt5: Box2D fixups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,6 @@ rock_library(envire
     maps/PolygonMap.cpp
     maps/TraversabilityGrid.cpp
     maps/TriMesh.cpp
-    operators/Projection.cpp
     operators/MLSProjection.cpp
     operators/MergeMLS.cpp
     operators/MergePointcloud.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,25 @@ endif()
 rock_add_public_dependencies(envire
     CMAKE GDAL)
 
+pkg_check_modules(box2d_pkgcfg QUIET box2d)
+if(box2d_pkgcfg_FOUND)
+    set(BOX2D_DEPS_PKGCONFIG box2d)
+    set(BOX2D_DEFINITIONS )
+    message(STATUS "box2d found using pkg-config")
+else()
+    find_package(box2d)
+    if(box2d_FOUND)
+        #with box2d 2.4, there was a reorganization that moved headers and functions around
+        #and also added the cmake configuration files
+        set(BOX2D_DEPS_CMAKE box2d)
+        set(BOX2D_LIBS box2d::box2d)
+        set(BOX2D_DEFINITIONS -DBOX2D_2_4)
+        message(STATUS "box2d found using cmake config")
+    else()
+        message(FATAL_ERROR "box2d could not be found using either pkg-config or cmake config")
+    endif()
+endif()
+
 rock_library(envire
     core/Environment.cpp
     core/FrameNode.cpp
@@ -59,9 +78,12 @@ rock_library(envire
     tools/GraphViz.cpp
     ${ADDITIONAL_SOURCES}
     HEADERS Core.hpp
-    DEPS_PKGCONFIG ply base-types base-lib base-logging box2d numeric
-    DEPS_CMAKE LibYAML GDAL
+    DEPS_PKGCONFIG ply base-types base-lib base-logging numeric ${BOX2D_DEPS_PKGCONFIG}
+    DEPS_CMAKE LibYAML GDAL ${BOX2D_DEPS_CMAKE}
+    LIBS ${BOX2D_LIBS}
     DEPS_PLAIN Boost_SYSTEM Boost_FILESYSTEM Boost_THREAD)
+
+target_compile_definitions(envire PRIVATE ${BOX2D_DEFINITIONS})
 
 install(FILES core/EventHandler.hpp
     core/Environment.hpp

--- a/src/maps/PolygonMap.cpp
+++ b/src/maps/PolygonMap.cpp
@@ -1,8 +1,14 @@
 #include "PolygonMap.hpp"
 #include <envire/core/Serialization.hpp>
+
+#ifdef BOX2D_2_4
+#include <box2d/b2_collision.h>
+#include <box2d/b2_distance.h>
+#include <box2d/box2d.h>
+#else
 #include <Box2D/Collision/b2Collision.h>
 #include <Box2D/Box2D.h>
-
+#endif
 
 namespace envire
 {  
@@ -149,7 +155,11 @@ bool PolygonSet::isInside(const envire::Polygon& poly)
     const b2PolygonShape *shape2 = &(data->collisionPoly->data->shape);
     
     //perform point test for every vertex in poly
+#ifdef BOX2D_2_4
+    for(int i = 0;i < shape1->m_count; i++)
+#else
     for(int i = 0;i < shape1->GetVertexCount(); i++)
+#endif
     {
 	if(!shape2->TestPoint(poly.data->pose, shape1->m_vertices[i]))
 	    return false;

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -28,8 +28,7 @@ target_link_libraries(envire-viz pthread)
 rock_executable(envireViewer envireViewer.cpp
     DEPS envire-viz
     DEPS_PKGCONFIG vizkit3d
-    DEPS_CMAKE GDAL box2d
-    LIBS Qt5::Core box2d::box2d)
+    LIBS Qt5::Core)
 target_link_libraries(envireViewer
     ${QT_QTGUI_LIBRARY})
     


### PR DESCRIPTION
This removes the box2d related changes intermingled in the qt5 work and then adds a better way to support both pre- and post version 2.4 box2d. This may actually be a candidate to be cherry-picked over to the master branch once box2d 2.4 lands in a relevant ubuntu. @planthaber 